### PR TITLE
prevent exclusion of equal sign in text

### DIFF
--- a/src/Tags/Map.php
+++ b/src/Tags/Map.php
@@ -210,7 +210,7 @@ class Map extends Tags
                 $markerTmpString = explode('|',$value);
                 foreach($markerTmpString as $option){
                     $optionKey = (explode('=',$option))[0];
-                    $optionValue = (explode('=',$option))[1];
+                    $optionValue = (explode('=',$option,2))[1];
                     match ($optionKey) {
                         'lat' => $lat = $optionValue,
                         'lon' => $lon = $optionValue,


### PR DESCRIPTION
The addon currently fails to allow any equal signs in marker text. This means that links like `'My <a href="/link">Link</a>'`will only show the text "My" in the marker. This is because when exploding marker attribute values, the php explode function is not given a limit.

This pull request adds that limit, allowing a much broader range of HTML in marker text as a result.