### PR TITLE
escape quotes from text

### DIFF
--- a/src/Tags/Map.php
+++ b/src/Tags/Map.php
@@ -210,7 +210,7 @@ class Map extends Tags
                 $markerTmpString = explode('|',$value);
                 foreach($markerTmpString as $option){
                     $optionKey = (explode('=',$option))[0];
-                    $optionValue = (explode('=',$option,2))[1];
+                    $optionValue = str_replace("'","\\'",(explode('=',$option,2))[1]);
                     match ($optionKey) {
                         'lat' => $lat = $optionValue,
                         'lon' => $lon = $optionValue,


### PR DESCRIPTION
I mentioned this on the other pull request, but the code was only in the comment, so it was not included when you merged that pull. So here is another pull request that also includes a change so that single quote marks in marker text do not break the maps.